### PR TITLE
Fix image name.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM matsumotory/ngx-mruby:latest
+FROM matsumotory/ngx_mruby:master
 MAINTAINER matsumotory
 
 #


### PR DESCRIPTION
matsumotory/ngx-mruby:latest doesn't exist any more.