### PR TITLE
Update image name in Dockerfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ configure arguments: --add-module=/usr/local/src/ngx_mruby --add-module=/usr/loc
 ### prepare nginx config and ngx_mruby hook files
 - `current_dir/Dockerfile`
 ```
-FROM matsumotory/ngx-mruby:latest
+FROM matsumotory/ngx_mruby:master
 MAINTAINER matsumotory
 ```
 - `current_dir/docker/conf/nginx.conf`


### PR DESCRIPTION
`matsumotory/ngx-mruby:latest` doesn't exist.
This change corresponds to the actual Dockerfile: https://github.com/a2ikm/docker-ngx_mruby/blob/master/Dockerfile#L1.
